### PR TITLE
Create directory for manifest if it doesn't exist

### DIFF
--- a/bitrot.go
+++ b/bitrot.go
@@ -137,6 +137,8 @@ func (cmd *Generate) Execute(args []string) (err error) {
 
 	manifestPath := filepath.Join(manifestDir, manifestFile.Filename)
 	if _, err := os.Stat(manifestPath); os.IsNotExist(err) {
+		err = os.MkdirAll(manifestDir, 0755)
+		check(err)
 		err = ioutil.WriteFile(manifestPath, manifestFile.JSONBytes, 0644)
 		check(err)
 


### PR DESCRIPTION
When generating a manifest for the first time, the app will panic if the
directory does not exist. This commit explicitly creates that directory.