### PR TITLE
Compute SHA1 checksum over streaming input

### DIFF
--- a/checksum.go
+++ b/checksum.go
@@ -8,16 +8,18 @@ import (
 )
 
 type sha1Reader struct {
-	hash   hash.Hash
-	reader io.ReadSeeker
+	hash       hash.Hash
+	reader     io.ReadSeeker
+	bufferSize int
 }
 
-func newSha1Reader(path string) *sha1Reader {
+func newSha1Reader(path string, bufferSize int) *sha1Reader {
 	file, err := os.Open(path)
 	check(err)
 	return &sha1Reader{
-		hash:   sha1.New(),
-		reader: file,
+		hash:       sha1.New(),
+		reader:     file,
+		bufferSize: bufferSize,
 	}
 }
 
@@ -34,9 +36,8 @@ func (r *sha1Reader) SHA1Sum() ([]byte, error) {
 }
 
 func (r *sha1Reader) readAll() (err error) {
-	readSize := 10 * 1024 * 1024
 	for {
-		b := make([]byte, readSize, readSize)
+		b := make([]byte, r.bufferSize, r.bufferSize)
 		n, err := r.reader.Read(b)
 		if err != nil && err != io.EOF {
 			return err

--- a/checksum.go
+++ b/checksum.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"crypto/sha1"
+	"hash"
+	"io"
+	"os"
+)
+
+type sha1Reader struct {
+	hash   hash.Hash
+	reader io.ReadSeeker
+}
+
+func newSha1Reader(path string) *sha1Reader {
+	file, err := os.Open(path)
+	check(err)
+	return &sha1Reader{
+		hash:   sha1.New(),
+		reader: file,
+	}
+}
+
+func (r *sha1Reader) SHA1Sum() ([]byte, error) {
+	_, err := r.reader.Seek(0, 0)
+	if err != nil {
+		return []byte{}, err
+	}
+	err = r.readAll()
+	if err != nil {
+		return []byte{}, err
+	}
+	return r.hash.Sum(nil), nil
+}
+
+func (r *sha1Reader) readAll() (err error) {
+	readSize := 10 * 1024 * 1024
+	for {
+		b := make([]byte, readSize, readSize)
+		n, err := r.reader.Read(b)
+		if err != nil && err != io.EOF {
+			return err
+		}
+		r.hash.Write(b[:n])
+		if err == io.EOF {
+			return nil
+		}
+	}
+	return nil
+}

--- a/checksum_test.go
+++ b/checksum_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestBufferSizeConfiguration(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "checksum")
+	check(err)
+
+	defer os.RemoveAll(tempDir)
+
+	populateTestDirectory(tempDir)
+	bufferSize := 1024
+	path := writeTestFile(tempDir, "foo", helloWorldString)
+	reader := newSha1Reader(path, bufferSize)
+	assert.Equal(t, 1024, reader.bufferSize)
+}

--- a/manifest.go
+++ b/manifest.go
@@ -50,7 +50,9 @@ func CompareManifests(oldManifest, newManifest *Manifest) *ManifestComparison {
 // Private functions
 
 func generateChecksum(file string) string {
-	reader := newSha1Reader(file)
+	// TODO: experiment with varying buffer to determine optimal size
+	bufferSize := 10 * 1024 * 1024 // 10MiB buffer
+	reader := newSha1Reader(file, bufferSize)
 	sum, err := reader.SHA1Sum()
 	check(err)
 	return hex.EncodeToString(sum)

--- a/manifest.go
+++ b/manifest.go
@@ -3,7 +3,6 @@ package main
 import (
 	"crypto/sha1"
 	"encoding/hex"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -51,10 +50,10 @@ func CompareManifests(oldManifest, newManifest *Manifest) *ManifestComparison {
 // Private functions
 
 func generateChecksum(file string) string {
-	data, err := ioutil.ReadFile(file)
+	reader := newSha1Reader(file)
+	sum, err := reader.SHA1Sum()
 	check(err)
-
-	return checksumHexString(&data)
+	return hex.EncodeToString(sum)
 }
 
 func checksumHexString(data *[]byte) string {


### PR DESCRIPTION
Previous approach of reading entire file first would cause massive
memory usage.