### PR TITLE
Normalize Unicode combining characters in paths

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -3,6 +3,7 @@ package main
 import (
 	"crypto/sha1"
 	"encoding/hex"
+	"golang.org/x/text/unicode/norm"
 	"os"
 	"path/filepath"
 	"time"
@@ -78,6 +79,8 @@ func directoryChecksums(path string, config *Config) map[string]ChecksumRecord {
 			var relPath string
 			relPath, err = filepath.Rel(path, entryPath)
 			check(err)
+			// Normalize Unicode combining characters
+			relPath = norm.NFC.String(relPath)
 			records[relPath] = ChecksumRecord{
 				Checksum: generateChecksum(entryPath),
 				ModTime:  info.ModTime().UTC(),


### PR DESCRIPTION
Different filesystems may represent the same file name with different
Unicode characters. For instance, on my Linux ext4 system, the name "ö"
is represented with the character U+00F6 (LATIN SMALL LETTER O WITH
DIAERESIS). In contrast, on MacOS, it is represented using decomposed
form: U+006F (LATIN SMALL LETTER O) followed by U+0308 (COMBINING
DIAERESIS).

Without normalization, paths containing these characters will be
incorrectly interpreted as added/deleted when moved to a different
filesystem, as the lookup in the manifest map is done by byte content
rather than normalized string.

Using [Unicode NFC][1], provided by the [unicode/norm][2] package, we
can always store the normalized form of the file path and avoid these
issues.

[1]: http://unicode.org/faq/normalization.html
[2]: https://blog.golang.org/normalization