### PR TITLE
Detect renames in manifest comparison

### DIFF
--- a/bitrot.go
+++ b/bitrot.go
@@ -243,6 +243,7 @@ func (cmd *CompareLatestManifests) Execute(args []string) (err error) {
 func manifestComparisonReportString(comparison *ManifestComparison) string {
 	return pathSection("Added", comparison.AddedPaths) +
 		pathSection("Deleted", comparison.DeletedPaths) +
+		renameSection(comparison.RenamedPaths) +
 		pathSection("Modified", comparison.ModifiedPaths) +
 		pathSection("Flagged", comparison.FlaggedPaths)
 }
@@ -257,6 +258,20 @@ func pathSection(description string, paths []string) string {
 		}
 	} else {
 		s += fmt.Sprintf("%s paths: none.\n", description)
+	}
+	return s
+}
+
+func renameSection(entries []RenamedPath) string {
+	s := ""
+	count := len(entries)
+	if count > 0 {
+		s += fmt.Sprint("Renamed paths:\n")
+		for _, entry := range entries {
+			s += fmt.Sprintf("    %s -> %s\n", entry.OldPath, entry.NewPath)
+		}
+	} else {
+		s += fmt.Sprint("Renamed paths: none.\n")
 	}
 	return s
 }

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -178,6 +178,7 @@ func TestManifestComparison(t *testing.T) {
 			"modified":           {Checksum: "qwer", ModTime: oldModTime},
 			"touched":            {Checksum: "olkm", ModTime: oldModTime},
 			"deleted":            {Checksum: "jklh", ModTime: oldModTime},
+			"renamedOld":         {Checksum: "xxxx", ModTime: oldModTime},
 		},
 	}
 
@@ -190,6 +191,7 @@ func TestManifestComparison(t *testing.T) {
 			"modified":           {Checksum: "tyui", ModTime: newModTime},
 			"touched":            {Checksum: "olkm", ModTime: newModTime},
 			"added":              {Checksum: "bnmv", ModTime: newModTime},
+			"renamedNew":         {Checksum: "xxxx", ModTime: oldModTime},
 		},
 	}
 
@@ -213,5 +215,10 @@ func TestManifestComparison(t *testing.T) {
 	expectedAddedPaths := []string{"added"}
 	if !reflect.DeepEqual(comparison.AddedPaths, expectedAddedPaths) {
 		t.Fatalf("expected AddedPaths %v; got %v", expectedAddedPaths, comparison.AddedPaths)
+	}
+
+	expectedRenamedPaths := []RenamedPath{{OldPath: "renamedOld", NewPath: "renamedNew"}}
+	if !reflect.DeepEqual(comparison.RenamedPaths, expectedRenamedPaths) {
+		t.Fatalf("expected RenamedPaths %v; got %v", expectedRenamedPaths, comparison.RenamedPaths)
 	}
 }


### PR DESCRIPTION
Resolves #1

Detect a pair of additions and deletions with the same checksum as a
rename.